### PR TITLE
adding TLS support for connection

### DIFF
--- a/kafkalogrus.go
+++ b/kafkalogrus.go
@@ -108,11 +108,11 @@ func (hook *KafkaLogrusHook) Fire(entry *logrus.Entry) error {
 
 	topic := hook.defaultTopic
 	if tsRaw, ok := entry.Data["topic"]; ok {
-		ts, ok := tsRaw.(string)
-		if !ok {
+		if ts, ok := tsRaw.(string); !ok {
 			return errors.New("Incorrect topic filed type (should be string)")
+		} else {
+			topic = ts
 		}
-		topic = ts
 	}
 	hook.producer.Input() <- &sarama.ProducerMessage{
 		Key:   partitionKey,

--- a/kafkalogrus.go
+++ b/kafkalogrus.go
@@ -1,6 +1,7 @@
 package kafkalogrus
 
 import (
+	"crypto/tls"
 	"errors"
 	"log"
 	"os"
@@ -10,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// KafkaLogrusHook
+// KafkaLogrusHook is the primary struct
 type KafkaLogrusHook struct {
 	id             string
 	defaultTopic   string
@@ -21,19 +22,28 @@ type KafkaLogrusHook struct {
 	producer       sarama.AsyncProducer
 }
 
-// Create a new KafkaHook
+// NewKafkaLogrusHook creates a new KafkaHook
 func NewKafkaLogrusHook(id string,
 	levels []logrus.Level,
 	formatter logrus.Formatter,
 	brokers []string,
 	defaultTopic string,
-	injectHostname bool) (*KafkaLogrusHook, error) {
+	injectHostname bool,
+	tls *tls.Config) (*KafkaLogrusHook, error) {
 	var err error
 	var producer sarama.AsyncProducer
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Producer.RequiredAcks = sarama.WaitForLocal       // Only wait for the leader to ack
 	kafkaConfig.Producer.Compression = sarama.CompressionSnappy   // Compress messages
 	kafkaConfig.Producer.Flush.Frequency = 500 * time.Millisecond // Flush batches every 500ms
+
+	// check here if provided *tls.Config is not nil and assign to the sarama config
+	// NOTE: we automatically enabled the TLS config because sarama would error out if our
+	//       config were non-nil but disabled. To avoid issue father down the stack, we enable.
+	if tls != nil {
+		kafkaConfig.Net.TLS.Enable = true
+		kafkaConfig.Net.TLS.Config = tls
+	}
 
 	if producer, err = sarama.NewAsyncProducer(brokers, kafkaConfig); err != nil {
 		return nil, err
@@ -63,14 +73,17 @@ func NewKafkaLogrusHook(id string,
 	return hook, nil
 }
 
+// Id returns the internal ID of the hook
 func (hook *KafkaLogrusHook) Id() string {
 	return hook.id
 }
 
+// Levels is required to implement the hook interface from logrus
 func (hook *KafkaLogrusHook) Levels() []logrus.Level {
 	return hook.levels
 }
 
+// Fire is required to implement the hook interface from logrus
 func (hook *KafkaLogrusHook) Fire(entry *logrus.Entry) error {
 	var partitionKey sarama.ByteEncoder
 	var b []byte
@@ -95,11 +108,11 @@ func (hook *KafkaLogrusHook) Fire(entry *logrus.Entry) error {
 
 	topic := hook.defaultTopic
 	if tsRaw, ok := entry.Data["topic"]; ok {
-		if ts, ok := tsRaw.(string); !ok {
+		ts, ok := tsRaw.(string)
+		if !ok {
 			return errors.New("Incorrect topic filed type (should be string)")
-		} else {
-			topic = ts
 		}
+		topic = ts
 	}
 	hook.producer.Input() <- &sarama.ProducerMessage{
 		Key:   partitionKey,

--- a/kafkalogrus_test.go
+++ b/kafkalogrus_test.go
@@ -15,7 +15,8 @@ func TestKafkaHook(t *testing.T) {
 		&logrus.JSONFormatter{},
 		[]string{"127.0.0.1:9092"},
 		"test",
-		true)
+		true,
+		nil)
 
 	if err != nil {
 		t.Errorf("Can not create KafkaHook: %v\n", err)


### PR DESCRIPTION
Add support for `*tls.Config` during initial hook creation.

Although configuring Kafka with SSL is a major PITA, for some workplaces/installations having a secure connection is required. The `sarama` binary already accepts incoming TLS connections as part of the client config so this change simply gives the user the ability to pass in their specific credentials.

I'd like to add a test to the binary as well but this would require an SSL kafka endpoint. Ping me if you'd like me to add as part of this PR.

PS: Thanks for pulling this together, very useful tool!